### PR TITLE
fix array[number] schema validation

### DIFF
--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -224,7 +224,7 @@ class Blumquist
         blumquistify_object(schema: sub_schema, data: item)
       end
 
-    elsif primitive_type?(type_def[:type]) || primitive_type?(type_def[:type].flatten.first)
+    elsif primitive_type?(type_def[:type]) || (type_def[:type].length == 1 && primitive_type?(type_def[:type].flatten.first))
 
     # We don't know what to do, so let's panic
     else

--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -224,7 +224,7 @@ class Blumquist
         blumquistify_object(schema: sub_schema, data: item)
       end
 
-    elsif primitive_type?(type_def[:type])
+    elsif primitive_type?(type_def[:type]) || primitive_type?(type_def[:type].flatten.first)
 
     # We don't know what to do, so let's panic
     else

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -75,9 +75,10 @@ describe Blumquist do
 
       it "correctly validates an array of numbers property" do
         event_schema=JSON.parse(open(File.join(support, "array_schema.json")).read)
-        data = JSON.parse('{"mentions":[1,2,3,4]}')
+        data = JSON.parse('{"mentions":[0,1,99,3,4]}')
         expect {
-          Blumquist.new(schema: event_schema, data: data)
+          blumquist_object = Blumquist.new(schema: event_schema, data: data)
+          expect(blumquist_object.mentions[2]).to eq 99
         }.to_not raise_error
 
       end

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -73,6 +73,15 @@ describe Blumquist do
         }.to_not raise_error
       end
 
+      it "correctly validates an array of numbers property" do
+        event_schema=JSON.parse(open(File.join(support, "array_schema.json")).read)
+        data = JSON.parse('{"mentions":[1,2,3,4]}')
+        expect {
+          Blumquist.new(schema: event_schema, data: data)
+        }.to_not raise_error
+
+      end
+
     end
 
 

--- a/spec/support/array_schema.json
+++ b/spec/support/array_schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "mentions": {
+            "type": [
+                "array"
+            ],
+            "description": "",
+            "items": [
+                {
+                    "type": [
+                        "number"
+                    ]
+                }
+            ]
+        }
+    },
+    "required": [
+        "mentions"
+    ]
+}


### PR DESCRIPTION
```
# Foo
- bar: (array[number], required)
```
breaks with: 

```
UnsupportedType: Unsupported type '["number"]' (["null,","boolean,","number,","string,","array","object"] are supported
```