### PR TITLE
Max length tests

### DIFF
--- a/blumquist.gemspec
+++ b/blumquist.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "activesupport"
-  spec.add_runtime_dependency "json-schema"
+  spec.add_runtime_dependency "json-schema", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -30,7 +30,20 @@ describe Blumquist do
       expect(b.phone_numbers[0].extension).to eq 1234
     end
 
+    let(:invalid_data_name_too_long) {
+      invalid = JSON.parse(data.to_json)
+      invalid['name'] = "Moviepilot GmbH, Moviepilot, Inc."
+      invalid
+    }
+
+    it "supports maxLength on strings" do
+      expect {
+        Blumquist.new(schema: schema, data: invalid_data_name_too_long, validate: true)
+      }.to raise_error(Blumquist::Errors::ValidationError)
+    end
+
     context "oneOf expressions" do
+
       it "with inline objects" do
         data = {"current_address" => {"planet" => "οὐρανός"}}
         blumquist = Blumquist.new(schema: schema, data: data)
@@ -51,7 +64,8 @@ describe Blumquist do
     end
 
     context "validation" do
-      let(:invalid_data) {
+
+      let(:invalid_data_name_as_number) {
         invalid = JSON.parse(data.to_json)
         invalid['name'] = 1
         invalid
@@ -59,12 +73,12 @@ describe Blumquist do
 
       it "is on by default" do
         expect {
-          Blumquist.new(schema: schema, data: invalid_data)
+          Blumquist.new(schema: schema, data: invalid_data_name_as_number)
         }.to raise_error(Blumquist::Errors::ValidationError)
       end
 
       it "can be switched off" do
-        b = Blumquist.new(schema: schema, data: invalid_data, validate: false)
+        b = Blumquist.new(schema: schema, data: invalid_data_name_as_number, validate: false)
         expect(b.name).to eq 1
       end
 

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -22,7 +22,7 @@ describe Blumquist do
     end
 
     it "has getters for arrays of references" do
-      expect(b.old_addresses[1].street_address).to eq "Bluecherstr. 22"
+      expect(b.old_addresses[2].street_address).to eq "Bluecherstr. 22"
     end
 
     it "has getters for arrays of objects" do

--- a/spec/support/data.json
+++ b/spec/support/data.json
@@ -2,11 +2,16 @@
   "name": "Moviepilot, Inc.",
   "phone_numbers": [{"prefix": 555, "extension": 1234}],
   "current_address": {
-    "street_address": "Friedrichstr. 58",
+    "street_address": "Chausseestr. 111",
     "city": "Berlin",
     "state": "Berlin"
   },
   "old_addresses": [
+    {
+      "street_address": "Friedrichstr. 58",
+      "city": "Berlin",
+      "state": "Berlin"
+    },
     {
       "street_address": "Mehringdamm 33",
       "city": "Berlin",

--- a/spec/support/schema.json
+++ b/spec/support/schema.json
@@ -16,7 +16,7 @@
   "type": "object",
 
   "properties": {
-    "name": { "type": "string" },
+    "name": { "type": "string", "maxLength": 16 },
     "phone_numbers": {
       "type": "array",
       "items": [{ "type": "object", "properties": { "prefix": {"type" :"number"}, "extension": {"type": "number"} }}]


### PR DESCRIPTION
Adds a test for `maxLength` validations and fixes json schema gem around `"~> 2.0"`. Also updates the addresses array in the fixtures, as I have heard Moviepilot moved to bigger offices.
