### PR TITLE
Fix one of getters

### DIFF
--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -175,6 +175,7 @@ class Blumquist
     # the first that matches:
     if sub_schema[:oneOf]
       primitive_allowed = false
+      matching_oneOf = nil
       sub_schema[:oneOf].each do |one|
         begin
           if primitive_type?(one[:type])
@@ -187,7 +188,7 @@ class Blumquist
                 definitions: @schema[:definitions]
               )
             end
-            return Blumquist.new(data: data, schema: schema, validate: true)
+            matching_oneOf = Blumquist.new(data: data, schema: schema, validate: true)
           end
         rescue
           # The data doesn't match this oneOf, but we declare the getters
@@ -197,6 +198,7 @@ class Blumquist
           # On to the next oneOf
         end
       end
+      return matching_oneOf if matching_oneOf
 
       # We found no matching object definition.
       # If a primitve is part of the `oneOfs,

--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -190,6 +190,10 @@ class Blumquist
             return Blumquist.new(data: data, schema: schema, validate: true)
           end
         rescue
+          # The data doesn't match this oneOf, but we declare the getters
+          # anyway, but as the blumquist could have these fields the getter
+          # should be available
+          one[:properties].each_key { |name| define_getter(name) }
           # On to the next oneOf
         end
       end

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -52,13 +52,6 @@ describe Blumquist do
         expect(blumquist.current_address.planet).to eq "οὐρανός"
       end
 
-      it "defines getters for all oneOfs, even if they do not appear in the data" do
-        data = { "name" => { "first_name" => "Mario" } }
-        blumquist = Blumquist.new(schema: oneOf_schema, data: data, validate: true)
-        expect(blumquist.name).to respond_to(:first_name)
-        expect(blumquist.name).to respond_to(:middle_name)
-      end
-
       it "with null objects" do
         data = {"current_address" => nil}
         blumquist = Blumquist.new(schema: schema, data: data)
@@ -69,6 +62,18 @@ describe Blumquist do
         schema = {"type" => "object", "properties": { "oo": {"type": "array", "items": {"oneOf": [{"type": "null"}]}}}}
         data = {"oo" => [{"invalid" => "object"}]}
         Blumquist.new(schema: schema, data: data, validate: false)
+      end
+
+      context "with oneOfs references that do not appear in the data" do
+        let(:blumquist) do
+          data = { "name" => { "first_name" => "Mario" } }
+          Blumquist.new(schema: oneOf_schema, data: data, validate: true)
+        end
+
+        it "defines getters for all oneOfs" do
+          expect(blumquist.name).to respond_to(:first_name)
+          expect(blumquist.name).to respond_to(:middle_name)
+        end
       end
     end
 

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -66,13 +66,19 @@ describe Blumquist do
 
       context "with oneOfs references that do not appear in the data" do
         let(:blumquist) do
-          data = { "name" => { "first_name" => "Mario" } }
+          data = { "name" => { "first_name" => "Mario", "last_name" => 'M' } }
           Blumquist.new(schema: oneOf_schema, data: data, validate: true)
         end
 
         it "defines getters for all oneOfs" do
           expect(blumquist.name).to respond_to(:first_name)
+          expect(blumquist.name).to respond_to(:maid_name)
+          expect(blumquist.name).to respond_to(:last_name)
           expect(blumquist.name).to respond_to(:middle_name)
+        end
+
+        it "does not overwrite the getters data" do
+          expect(blumquist.name.last_name).to eq 'M'
         end
       end
     end

--- a/spec/blumquist_spec.rb
+++ b/spec/blumquist_spec.rb
@@ -11,6 +11,7 @@ describe Blumquist do
   context 'generating getters' do
     let(:support) { File.expand_path("../support", __FILE__) }
     let(:schema) { JSON.parse(open(File.join(support, 'schema.json')).read) }
+    let(:oneOf_schema) { JSON.parse(open(File.join(support, 'oneOf_schema.json')).read) }
     let(:data) { JSON.parse(open(File.join(support, 'data.json')).read) }
     let(:b) { Blumquist.new(schema: schema, data: data) }
 
@@ -49,6 +50,13 @@ describe Blumquist do
         data = {"current_address" => {"planet" => "οὐρανός"}}
         blumquist = Blumquist.new(schema: schema, data: data)
         expect(blumquist.current_address.planet).to eq "οὐρανός"
+      end
+
+      it "defines getters for all oneOfs, even if they do not appear in the data" do
+        data = { "name" => { "first_name" => "Mario" } }
+        blumquist = Blumquist.new(schema: oneOf_schema, data: data, validate: true)
+        expect(blumquist.name).to respond_to(:first_name)
+        expect(blumquist.name).to respond_to(:middle_name)
       end
 
       it "with null objects" do

--- a/spec/support/oneOf_schema.json
+++ b/spec/support/oneOf_schema.json
@@ -5,9 +5,18 @@
     "old_fields": {
       "type": "object",
       "properties": {
-        "middle_name": { "type": "string" }
+        "middle_name": { "type": "string" },
+        "last_name": { "type": "string" }
       },
       "required": ["middle_name"]
+    },
+    "with_extra_fields": {
+      "type": "object",
+      "properties": {
+        "maid_name": { "type": "string" },
+        "last_name": { "type": "string" }
+      },
+      "required": ["maiden_name"]
     }
   },
 
@@ -17,14 +26,16 @@
     "name": {
       "oneOf": [
         { "type": "null" },
-        {"$ref": "#/definitions/old_fields" },
+        {"$ref": "#/definitions/with_extra_fields" },
         {
           "type": "object",
           "properties": {
-            "first_name": { "type" : "string" }
+            "first_name": { "type" : "string" },
+            "last_name": { "type" : "string" }
           },
           "required": ["first_name"]
-        }
+        },
+        {"$ref": "#/definitions/old_fields" }
       ]
     } 
   }

--- a/spec/support/oneOf_schema.json
+++ b/spec/support/oneOf_schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+
+  "definitions": {
+    "old_fields": {
+      "type": "object",
+      "properties": {
+        "middle_name": { "type": "string" }
+      },
+      "required": ["middle_name"]
+    }
+  },
+
+  "type": "object",
+
+  "properties": {
+    "name": {
+      "oneOf": [
+        { "type": "null" },
+        {"$ref": "#/definitions/old_fields" },
+        {
+          "type": "object",
+          "properties": {
+            "first_name": { "type" : "string" }
+          },
+          "required": ["first_name"]
+        }
+      ]
+    } 
+  }
+}


### PR DESCRIPTION
Problem: If you have a schema something like:
allowing object like `{ 'name' => 'David'}` or `{ 'first_name' => 'David' }`

```ruby
data = { 'name' => 'David'}
b = Blumquist.new(data: data, schema: schema, validate: true)
```

Current:
```ruby
b.first_name
=> undefined method `first_name' for #<Blumquist:0x007f727f6c61e8>
```
Expected:
```ruby
b.first_name
=> nil
```

The current implementation makes sense if you know the data contained in the blumquist, but if you don't then you would need to prepend everything with `blumquist.respond_to?(:my_method).