### PR TITLE
Generate pretty errors for validation errors

### DIFF
--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -45,7 +45,7 @@ class Blumquist
     return unless @validate
     errors = JSON::Validator.fully_validate(@schema, @data)
     return true if errors.length == 0
-    raise(Errors::ValidationError, [errors, @schema, @data])
+    raise(Errors::ValidationError, [errors, @data, @schema])
   end
 
   def validate_schema

--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -45,7 +45,7 @@ class Blumquist
     return unless @validate
     errors = JSON::Validator.fully_validate(@schema, @data)
     return true if errors.length == 0
-    raise(Errors::ValidationError, [errors, @data, @schema])
+    raise(Errors::ValidationError, [errors.map { |e| e.split("\n") }, @data])
   end
 
   def validate_schema

--- a/lib/blumquist/errors/validation.rb
+++ b/lib/blumquist/errors/validation.rb
@@ -2,7 +2,7 @@ class Blumquist
   module Errors
     class ValidationError < Blumquist::Error
       def initialize(errors)
-        super(errors.to_json)
+        super(JSON.pretty_generate(JSON.parse(errors.to_json)))
       end
     end
   end


### PR DESCRIPTION
Instead of
```
     Blumquist::Errors::ValidationError:
       [["The property '#/name' of type integer did not match the following type: string in schema 658659b8-41dc-5211-
9cb4-0912a8ab1cc4"],{"$schema":"http://json-schema.org/draft-04/schema#","definitions":{"address":{"type":"object","pr
operties":{"street_address":{"type":"string"},"city":{"type":"string"},"state":{"type":["string","null"]}},"required":
["street_address","city","state"]},"sibling":{"type":"object","properties":{"age_difference":{"type":"number"},"name":
{"type":"string"}},"required":["age_difference"]},"ancestor":{"type":"object","properties":{"family_name":{"type":"str
ing"}},"required":["family_name"]}},"type":"object","properties":{"name":{"type":"string","maxLength":16},"phone_numbe
rs":{"type":"array","items":[{"type":"object","properties":{"prefix":{"type":"number"},"extension":{"type":"number"}}}
]},"parents_address":{"$ref":"#/definitions/address"},"current_address":{"oneOf":[{"type":"null"},{"$ref":"#/definitio
ns/address"},{"type":"object","properties":{"planet":{"type":"string"}},"required":["planet"]}]},"relatives":{"type":"
array","items":{"oneOf":[{"$ref":"#/definitions/sibling"},{"$ref":"#/definitions/ancestor"}]}},"old_addresses":{"type"
:"array","items":[{"$ref":"#/definitions/address"}]}}},{"name":1,"phone_numbers":[{"prefix":555,"extension":1234}],"cu
rrent_address":{"street_address":"Chausseestr. 111","city":"Berlin","state":"Berlin"},"old_addresses":[{"street_addres
s":"Friedrichstr. 58","city":"Berlin","state":"Berlin"},{"street_address":"Mehringdamm 33","city":"Berlin","state":"Be
rlin"},{"street_address":"Bluecherstr. 22","city":"Berlin","state":"Berlin"}]}]
```
You see:
```
Blumquist::Errors::ValidationError:
  [
    [
      "The property '#/name' of type integer did not match the following type: string in schema 658659b8-41dc-5211-9cb4-0912a8ab1cc4"
    ],
    {
      "name": 1,
      "phone_numbers": [
        {
          "prefix": 555,
          "extension": 1234
        }
      ],
      "current_address": {
        "street_address": "Chausseestr. 111",
        "city": "Berlin",
        "state": "Berlin"
      },
      "old_addresses": [
        {
          "street_address": "Friedrichstr. 58",
          "city": "Berlin",
          "state": "Berlin"
        },
        {
          "street_address": "Mehringdamm 33",
          "city": "Berlin",
          "state": "Berlin"
        },
        {
          "street_address": "Bluecherstr. 22",
          "city": "Berlin",
          "state": "Berlin"
        }
      ]
    },
    {
      "$schema": "http://json-schema.org/draft-04/schema#",
      "definitions": {
        "address": {
          "type": "object",
          "properties": {
            "street_address": {
              "type": "string"
            },
            "city": {
              "type": "string"
            },
            "state": {
              "type": [
                "string",
                "null"
              ]
            }
          },
          "required": [
            "street_address",
            "city",
            "state"
          ]
        },
        "sibling": {
          "type": "object",
          "properties": {
            "age_difference": {
              "type": "number"
            },
            "name": {
              "type": "string"
            }
          },
          "required": [
            "age_difference"
          ]
        },
        "ancestor": {
          "type": "object",
          "properties": {
            "family_name": {
              "type": "string"
            }
          },
          "required": [
            "family_name"
          ]
        }
      },
      "type": "object",
      "properties": {
        "name": {
          "type": "string",
          "maxLength": 16
        },
        "phone_numbers": {
          "type": "array",
          "items": [
            {
              "type": "object",
              "properties": {
                "prefix": {
                  "type": "number"
                },
                "extension": {
                  "type": "number"
                }
              }
            }
          ]
        },
        "parents_address": {
          "$ref": "#/definitions/address"
        },
        "current_address": {
          "oneOf": [
            {
              "type": "null"
            },
            {
              "$ref": "#/definitions/address"
            },
            {
              "type": "object",
              "properties": {
                "planet": {
                  "type": "string"
                }
              },
              "required": [
                "planet"
              ]
            }
          ]
        },
        "relatives": {
          "type": "array",
          "items": {
            "oneOf": [
              {
                "$ref": "#/definitions/sibling"
              },
              {
                "$ref": "#/definitions/ancestor"
              }
            ]
          }
        },
        "old_addresses": {
          "type": "array",
          "items": [
            {
              "$ref": "#/definitions/address"
            }
          ]
        }
      }
    }
  ]
```
It is quite long but it's at least readable. Do you think we could remove the schema from the exception? The schema should be available for the user somewhere, but then you can't find the error by just looking at the exception. 