### PR TITLE
Support integer primitive type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# [0.9.1] - 2017-09-04 Alfonso Mancilla (#20)
+- Support primitive type: integer.
+
 # 0.9.0
 - Allow enums
 

--- a/lib/blumquist.rb
+++ b/lib/blumquist.rb
@@ -79,7 +79,7 @@ class Blumquist
   end
 
   def primitive_type?(type)
-    %w{null boolean number string enum}.include? type.to_s
+    %w{null boolean number string enum integer}.include?(type.to_s)
   end
 
   def define_getters

--- a/lib/blumquist/version.rb
+++ b/lib/blumquist/version.rb
@@ -1,3 +1,3 @@
 class Blumquist
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/spec/support/schema.json
+++ b/spec/support/schema.json
@@ -14,7 +14,7 @@
     "sibling": {
       "type": "object",
       "properties": {
-        "age_difference": { "type": "number" },
+        "age_difference": { "type": "integer" },
         "name":           { "type": "string" }
       },
       "required": ["age_difference"]


### PR DESCRIPTION
`integer` != `number` type as per: https://spacetelescope.github.io/understanding-json-schema/reference/numeric.html